### PR TITLE
fix(php-coding-standards): emit checkstyle to stdout for cs2pr

### DIFF
--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -15,7 +15,7 @@ on:
         type: string
       PHPCS_ARGS:
         description: Set of arguments passed to PHP_CodeSniffer.
-        default: '--report-full --report-checkstyle=./phpcs-report.xml'
+        default: '-q --report=checkstyle'
         required: false
         type: string
     secrets:


### PR DESCRIPTION
## Problem

The `php-coding-standards` reusable workflow pipes phpcs's **text** report into `cs2pr`, which expects **checkstyle XML**:

```
./vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml <files> | cs2pr
```

`--report-full` writes the human-readable report to **stdout**; the checkstyle XML goes to a **file** no later step reads. So cs2pr gets non-XML on stdin and dies:

```
Error: Start tag expected, '<' not found on line 1, column 1
##[error]Process completed with exit code 2.
```

This happens on **every** run regardless of findings — so the check has failed on every PHP-touching commit in every consuming repo (only no-PHP commits like release bumps go green).

## Fix

Mirror the working `php-static-analysis` job, which already does `--error-format=checkstyle | cs2pr`. Emit checkstyle to **stdout** and let cs2pr parse it:

```
PHPCS_ARGS default: '-q --report=checkstyle'
```

`-q` keeps phpcs's deprecated-sniff warning off stdout (it would otherwise pollute the XML). The unused `phpcs-report.xml` file is dropped.

## Impact

Fixes phpcs CI for every repo using this workflow. Clean PHP changes now pass; real violations surface as proper PR annotations and fail the check correctly (instead of the blanket parse-error failure).

Verified locally: `phpcs -q --report=checkstyle <clean file>` emits an empty `<checkstyle/>` and exits 0 — exactly what cs2pr consumes successfully in the phpstan job.