### PR TITLE
fix(php-coding-standards): emit checkstyle to stdout for cs2pr

### DIFF
--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -15,7 +15,7 @@ on:
         type: string
       PHPCS_ARGS:
         description: Set of arguments passed to PHP_CodeSniffer.
-        default: '--report-full --report-checkstyle=./phpcs-report.xml'
+        default: '-q --report=checkstyle'
         required: false
         type: string
     secrets:


### PR DESCRIPTION
The phpcs job piped `--report-full` (human-readable text on stdout) into cs2pr while writing the checkstyle XML to a file nothing reads. cs2pr expects checkstyle XML on stdin, so it failed to parse it ("Start tag expected, '<' not found") and the step exited 2 on every run, regardless of phpcs findings. The check has therefore failed on every PHP-touching commit in every consuming repo; only commits that change no PHP (e.g. release bumps) went green.

Mirror the working php-static-analysis job (`--error-format=checkstyle | cs2pr`): output checkstyle to stdout with `-q` so the deprecated-sniff warning doesn't pollute stdout, and let cs2pr parse it. The unused phpcs-report.xml file is dropped.