### PR TITLE
feat: add smoke-gate composite action for the PR-clone merge gate

### DIFF
--- a/.github/actions/smoke-gate/action.yml
+++ b/.github/actions/smoke-gate/action.yml
@@ -1,0 +1,58 @@
+name: 'Smoke gate'
+description: >-
+  Merge gate for the PR-clone smoke deploy. Reports the single required status
+  check for `mind updates:protect`. Passes unless a mind-owned update/* PR's
+  clone smoke deploy failed to pass: manual PRs are waived (mergeable by
+  anyone), update branches must show a green smoke deploy. Keying the waive on
+  the branch — not the label or a skipped job — stops a removed label or an
+  open/label race from waiving an update into an untested auto-merge.
+inputs:
+  determine-result:
+    description: Result of the `determine` gate job (success/failure/...).
+    required: true
+    type: string
+  smoke-result:
+    description: Result of the `smoke-test` clone-deploy job (success/skipped/failure/...).
+    required: true
+    type: string
+  head-ref:
+    description: The PR head branch (github.head_ref).
+    required: true
+    type: string
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        DETERMINE: ${{ inputs.determine-result }}
+        SMOKE: ${{ inputs.smoke-result }}
+        HEAD_REF: ${{ inputs.head-ref }}
+      run: |
+        if [ "$DETERMINE" != 'success' ]; then
+          echo "determine=$DETERMINE — cannot evaluate the gate."
+          exit 1
+        fi
+        # A green smoke deploy always passes; a failed/cancelled one always
+        # blocks. A skipped smoke is waived ONLY for manual branches — a
+        # mind-owned update/* branch must smoke, so a skip there blocks rather
+        # than letting auto-merge land an untested update.
+        case "$SMOKE" in
+          success)
+            echo "smoke deploy passed."
+            ;;
+          skipped)
+            case "$HEAD_REF" in
+              update/patch|update/minor|update/major)
+                echo "update PR but smoke deploy was skipped — blocking (won't auto-merge untested)."
+                exit 1
+                ;;
+              *)
+                echo "manual PR ($HEAD_REF) — smoke deploy not applicable, waived."
+                ;;
+            esac
+            ;;
+          *)
+            echo "smoke deploy did not pass (smoke-test=$SMOKE) — blocking."
+            exit 1
+            ;;
+        esac


### PR DESCRIPTION
## What

Adds a `smoke-gate` **composite action** — the single required status check for the PR-clone merge gate (`mind updates:protect`). It centralises the gate logic that mind-cli currently embeds in every repo's `pr-clone-deploy.yml`.

## Why a composite action (not a reusable workflow)

The required check must be a **plain, always-reported** job context called `smoke-gate`. A reusable workflow (`uses:` at job level) would make the context **nested** (`smoke-gate / <job>`) — the same fragile shape as the old `smoke-test / deploy` that never reported when its caller was gated off. A composite action (`uses:` at **step** level, inside a normal job) keeps the clean `smoke-gate` context while moving the logic here, so it can change fleet-wide without re-scaffolding each repo.

## Behavior (verified)

| head branch | smoke deploy | gate |
| --- | --- | --- |
| manual (`feat/…`) | skipped | **pass** (waived — mergeable by anyone) |
| manual | failed | block |
| `update/{patch,minor,major}` | passed | pass |
| `update/*` | **skipped** (label removed / open-label race) | **block** (won't auto-merge untested) |
| `update/*` | failed | block |
| — | `determine` failed | block |

Keying the waive on the branch (not the label or a skipped job) is deliberate: it stops a removed label or the open/label race from waiving an update into an untested auto-merge.

## Consumed by

mind-cli's generated `pr-clone-deploy.yml` calls this at `@main`:

```yaml
- uses: mindkomm/workflows/.github/actions/smoke-gate@main
  with:
    determine-result: ${{ needs.determine.result }}
    smoke-result: ${{ needs.smoke-test.result }}
    head-ref: ${{ github.head_ref }}
```

Merge this first — the matching mind-cli template change references it at `@main`.
