### PR TITLE
feat(php-coding-standards): don't fail the build on PHPCS warnings by default

### DIFF
--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -14,8 +14,13 @@ on:
         required: false
         type: string
       PHPCS_ARGS:
-        description: Set of arguments passed to PHP_CodeSniffer.
-        default: '-q --report=checkstyle'
+        description: Set of arguments passed to PHP_CodeSniffer. Warnings don’t fail the build by default (`ignore_warnings_on_exit`); pass `-q --report=checkstyle` to make them blocking again.
+        default: '-q --report=checkstyle --runtime-set ignore_warnings_on_exit 1'
+        required: false
+        type: string
+      CS2PR_ARGS:
+        description: Set of arguments passed to cs2pr. Defaults to `--graceful-warnings` so warnings are annotated but don’t fail the build; pass an empty string to make them blocking.
+        default: '--graceful-warnings'
         required: false
         type: string
     secrets:
@@ -47,4 +52,4 @@ jobs:
 
       - name: Run PHP_CodeSniffer
         if: steps.changed-files.outputs.all_changed_files != ''
-        run: ./vendor/bin/phpcs ${{ inputs.PHPCS_ARGS }} ${{ join(steps.changed-files.outputs.all_changed_files, ' ') }} | cs2pr
+        run: ./vendor/bin/phpcs ${{ inputs.PHPCS_ARGS }} ${{ join(steps.changed-files.outputs.all_changed_files, ' ') }} | cs2pr ${{ inputs.CS2PR_ARGS }}


### PR DESCRIPTION
## Problem

`php-coding-standards.yml` runs `phpcs … | cs2pr`. With `pipefail` (the default GitHub Actions bash mode), the step fails if **either** side exits non-zero — and both fail on warnings:

- `phpcs` exits `1` when there are any warnings,
- `cs2pr` exits non-zero on warnings unless `--graceful-warnings` is passed.

So a warning-only run (e.g. line length, missing nonce) failed the whole check. Fixing this in a consumer’s `phpcs.xml` can’t work: it can silence phpcs, but not cs2pr.

## Change

Make warnings **annotated but non-blocking by default**, configurable via raw args (no per-flag boolean mapping):

- `PHPCS_ARGS` default now includes `--runtime-set ignore_warnings_on_exit 1`.
- New `CS2PR_ARGS` input (default `--graceful-warnings`), mirroring the existing `PHPCS_ARGS` passthrough on the cs2pr side.

Errors still fail the build. Warnings still show up as PR annotations.

## Restoring strict behaviour

```yaml
with:
  PHPCS_ARGS: '-q --report=checkstyle'
  CS2PR_ARGS: ''
```

## Note

The two flags are coupled by convention, not a single switch: a consumer that overrides `PHPCS_ARGS` must keep `--runtime-set ignore_warnings_on_exit 1` for warnings to stay non-blocking (pipefail still sees phpcs’s exit code).