### PR TITLE
Deployer phar in CI: pull dep.phar, fold rollback into a command input

### DIFF
--- a/.github/actions/deployer/action.yml
+++ b/.github/actions/deployer/action.yml
@@ -1,0 +1,39 @@
+name: 'Deployer'
+description: 'Set up PHP and download the mindkomm/deployer dep.phar from its release.'
+
+inputs:
+  php-version:
+    description: PHP version on the runner
+    default: '8.3'
+    required: false
+  deployer-version:
+    description: 'mindkomm/deployer release tag (unprefixed, e.g. 1.10.0). Empty = latest.'
+    default: ''
+    required: false
+  read-phar-token:
+    description: GitHub token with read access to mindkomm/deployer releases.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up PHP
+      uses: shivammathur/setup-php@fcafdd6392932010c2bd5094439b8e33be2a8a09 # 2.37.0
+      with:
+        php-version: ${{ inputs.php-version }}
+        tools: none
+
+    - name: Download dep.phar
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.read-phar-token }}
+        DEPLOYER_VERSION: ${{ inputs.deployer-version }}
+      run: |
+        set -euo pipefail
+        ARGS=(--repo mindkomm/deployer --pattern dep.phar -O dep.phar --clobber)
+        if [ -n "$DEPLOYER_VERSION" ]; then
+          gh release download "$DEPLOYER_VERSION" "${ARGS[@]}"
+        else
+          gh release download "${ARGS[@]}"
+        fi
+        php -r 'exit(is_readable("dep.phar") && filesize("dep.phar") > 0 ? 0 : 1);'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,9 +31,21 @@ on:
         type: string
         default: ''
       composer-args:
-        description: Arguments passed to composer install
+        description: Arguments passed to composer install (host-side only; unused on the runner since the switch to dep.phar)
         type: string
         default: '--prefer-dist --no-progress'
+      deployer-version:
+        description: 'mindkomm/deployer release tag (unprefixed, e.g. 1.10.0). Empty = latest.'
+        type: string
+        default: ''
+      command:
+        description: 'deploy (default) or rollback'
+        type: string
+        default: 'deploy'
+      rollback-to:
+        description: 'Release number to roll back to (blank = previous). Only used when command=rollback.'
+        type: string
+        default: ''
       environment:
         description: 'GitHub Environment name (e.g. production, staging, or clone-<slug>). Required — empty value would make GH reject the environment block.'
         type: string
@@ -46,6 +58,9 @@ on:
       COMPOSER_AUTH_JSON:
         description: Composer auth JSON for private repositories
         required: false
+      READ_PHAR:
+        description: Token with read access to mindkomm/deployer releases
+        required: true
       DEPLOYER_SSH_KEY:
         description: SSH private key authorized on the deploy target
         required: true
@@ -69,10 +84,11 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - uses: mindkomm/workflows/.github/actions/composer@main
+      - uses: mindkomm/workflows/.github/actions/deployer@main
         with:
-          PHP_VERSION: ${{ inputs.php-version }}
-          COMPOSER_ARGS: ${{ inputs.composer-args }}
+          php-version: ${{ inputs.php-version }}
+          deployer-version: ${{ inputs.deployer-version }}
+          read-phar-token: ${{ secrets.READ_PHAR }}
 
       - name: Set up SSH agent
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
@@ -103,13 +119,18 @@ jobs:
           ARGS=()
           [ -n "$DEPLOY_HOST" ] && ARGS+=("$DEPLOY_HOST")
           ARGS+=("--slug=$DEPLOY_SLUG")
-          ./vendor/bin/dep deploy:unlock "${ARGS[@]}" || true
+          php dep.phar deploy:unlock "${ARGS[@]}" || true
 
-      - name: Deploy
+      # Runs `deploy` (default) or `rollback` off the `command` input — rollback
+      # only changes the deployer subcommand, so it lives here, not in a separate
+      # workflow. On push/plain deploys `command` is 'deploy'.
+      - name: Run deployer
         env:
           DEPLOY_HOST: ${{ inputs.host }}
           DEPLOY_SLUG: ${{ inputs.slug }}
           DEPLOY_BRANCH: ${{ inputs.branch }}
+          DEPLOY_COMMAND: ${{ inputs.command }}
+          ROLLBACK_TO: ${{ inputs.rollback-to }}
           # A non-empty slug means this is a clone/smoke-test deploy: it has no
           # dedicated web server, and cachetool_web_url targets the canonical
           # host — so the deployer skips OPcache clearing on this run (a missed
@@ -117,8 +138,13 @@ jobs:
           MIND_CLONE_DEPLOY: ${{ inputs.slug != '' && '1' || '' }}
         run: |
           set -euo pipefail
+          COMMAND="${DEPLOY_COMMAND:-deploy}"
           ARGS=()
           [ -n "$DEPLOY_HOST" ] && ARGS+=("$DEPLOY_HOST")
-          [ -n "$DEPLOY_SLUG" ] && ARGS+=("--slug=$DEPLOY_SLUG")
-          [ -n "$DEPLOY_BRANCH" ] && ARGS+=("--branch=$DEPLOY_BRANCH")
-          ./vendor/bin/dep deploy -vv "${ARGS[@]}"
+          if [ "$COMMAND" = "rollback" ]; then
+            [ -n "$ROLLBACK_TO" ] && ARGS+=("--rollback-to=$ROLLBACK_TO")
+          else
+            [ -n "$DEPLOY_SLUG" ] && ARGS+=("--slug=$DEPLOY_SLUG")
+            [ -n "$DEPLOY_BRANCH" ] && ARGS+=("--branch=$DEPLOY_BRANCH")
+          fi
+          php dep.phar "$COMMAND" -vv "${ARGS[@]}"

--- a/.github/workflows/instance-destroy.yml
+++ b/.github/workflows/instance-destroy.yml
@@ -15,13 +15,20 @@ on:
         type: string
         required: true
       composer-args:
-        description: Arguments passed to composer install
+        description: Arguments passed to composer install (host-side only; unused on the runner since the switch to dep.phar)
         type: string
         default: '--prefer-dist --no-progress'
+      deployer-version:
+        description: 'mindkomm/deployer release tag (unprefixed, e.g. 1.10.0). Empty = latest.'
+        type: string
+        default: ''
     secrets:
       COMPOSER_AUTH_JSON:
         description: Composer auth JSON for private repositories
         required: false
+      READ_PHAR:
+        description: Token with read access to mindkomm/deployer releases
+        required: true
       DEPLOYER_SSH_KEY:
         description: SSH private key authorized on the deploy target
         required: true
@@ -40,10 +47,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - uses: mindkomm/workflows/.github/actions/composer@main
+      - uses: mindkomm/workflows/.github/actions/deployer@main
         with:
-          PHP_VERSION: ${{ inputs.php-version }}
-          COMPOSER_ARGS: ${{ inputs.composer-args }}
+          php-version: ${{ inputs.php-version }}
+          deployer-version: ${{ inputs.deployer-version }}
+          read-phar-token: ${{ secrets.READ_PHAR }}
 
       - name: Set up SSH agent
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
@@ -59,4 +67,4 @@ jobs:
       - name: Destroy instance
         env:
           DEPLOY_SLUG: ${{ inputs.slug }}
-        run: ./vendor/bin/dep instance:destroy -vv --slug="$DEPLOY_SLUG" --force
+        run: php dep.phar instance:destroy -vv --slug="$DEPLOY_SLUG" --force

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -38,8 +38,8 @@ on:
       UPDATES_PAT:
         description: PAT with contents:write + pull-requests:write on the consumer repo. Required so PRs trigger downstream workflows (default GITHUB_TOKEN does not).
         required: true
-      MIND_CLI_READ_TOKEN:
-        description: PAT with read access to mindkomm/mind-cli for fetching the phar. Separate from UPDATES_PAT so each token is scoped to one purpose. Best as an org-level secret since it's identical across mindkomm projects.
+      READ_PHAR:
+        description: PAT with read access to mindkomm release phars (mind-cli + deployer). Best as an org-level secret since it's identical across mindkomm projects.
         required: true
 
 permissions: {}
@@ -74,7 +74,7 @@ jobs:
         env:
           # Use the download-only token here, not UPDATES_PAT — UPDATES_PAT is
           # scoped to the consumer repo and won't see mindkomm/mind-cli.
-          GH_TOKEN: ${{ secrets.MIND_CLI_READ_TOKEN }}
+          GH_TOKEN: ${{ secrets.READ_PHAR }}
           MIND_VERSION: ${{ inputs.mind-version }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
Pull the `mindkomm/deployer` phar in CI instead of installing it via Composer, so consumer projects don't need it as a dev dependency.

## Changes

- New `deployer` composite action: sets up PHP and downloads `dep.phar`.
- `deploy.yml` and `instance-destroy.yml` run the phar directly (no runner-side composer install).
- `deploy.yml` gains `command` (`deploy`/`rollback`), `rollback-to`, and `deployer-version` inputs — rollback runs through the same workflow.
- Workflows read the phar via a dedicated token secret.

## Verification

- [x] `actionlint` clean on the changed workflows
- [ ] deploy + rollback smoke on a test project